### PR TITLE
Allow Whizbang migrations to be published

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ php artisan migrate
 composer require ludovicguenet/whizbang
 ```
 
-### Publish Config
+### Publish Config and Migrations
 
 ```bash
 php artisan vendor:publish --tag=whizbang-config
+php artisan vendor:publish --tag=whizbang-migrations
 ```
 
 ### Run Migrations

--- a/src/WhizbangServiceProvider.php
+++ b/src/WhizbangServiceProvider.php
@@ -26,7 +26,9 @@ class WhizbangServiceProvider extends ServiceProvider
             __DIR__.'/../config/whizbang.php' => config_path('whizbang.php'),
         ], 'whizbang-config');
 
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->publishesMigrations([
+            __DIR__.'/../database/migrations' => database_path('migrations'),
+        ], 'whizbang-migrations');
 
         if ($this->app->runningInConsole()) {
             $this->commands([


### PR DESCRIPTION
The Whizbang migrations were not published by default and the README didn't mention any steps to do so.

This pull request allows the Whizbang migrations to be published and updates the README with the relevant command to do so. This should fix Issue #5.

Without explicitly specifying a publishable tagged migration command, the other option with the original code would be to run:

```bash
php artisan vendor:publish
```

and then the user would specifically need to choose the `Ludovicguenet\Whizbang\WhizbangServiceProvider` from the list of all the other providers.